### PR TITLE
Fix | Dependabot Github Token error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,5 +50,5 @@ jobs:
       contents: write
     steps:
       - uses: fastify/github-action-merge-dependabot@v3.9.1
-        # with:
-        #   github-token: ${{secrets.PA_TOKEN}}
+        with:
+          github-token: ${{secrets.PA_TOKEN}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,5 +50,5 @@ jobs:
       contents: write
     steps:
       - uses: fastify/github-action-merge-dependabot@v3.9.1
-        with:
-          github-token: ${{secrets.PA_TOKEN}}
+        # with:
+        #   github-token: ${{secrets.PA_TOKEN}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,4 +51,4 @@ jobs:
     steps:
       - uses: fastify/github-action-merge-dependabot@v3.9.1
         with:
-          github-token: ${{secrets.PA_TOKEN}}
+          github-token: ${{secrets.PA_TOKEN || github.token}}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,5 +50,3 @@ jobs:
       contents: write
     steps:
       - uses: fastify/github-action-merge-dependabot@v3.9.1
-        with:
-          github-token: ${{secrets.PA_TOKEN || github.token}}


### PR DESCRIPTION
This action has been failing with this error `unhandled error: error: input required and not supplied: github-token` , this explains why it has been happening. As a security precaution dependabot PRs have no access to github secrets https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/