### PR TITLE
Add dumb tables

### DIFF
--- a/src/core/tables/Tables.js
+++ b/src/core/tables/Tables.js
@@ -4,7 +4,7 @@ import fetchData, { fetchDataFromAPI } from '../../utils/data';
 import DistrictTable from '../components/DistrictTable';
 import renderSelectors from '../SelectorDropdowns';
 import { defaultSelectValue, filterDataByProperty, filterDataBySubCounty } from '../utils';
-import { parseScoreCardTableData, parseTableData, validConfigs } from '../utils/tables';
+import { parseScoreCardTableData, parseTableData, validConfigs, parseDumbTableData } from '../utils/tables';
 import ScoreCardTable from '../components/ScoreCardTable';
 
 const handleSelectors = async ({ data, config, subCounty, tableRoot }, selectorNodes, tableType, thresholds) => {
@@ -82,6 +82,9 @@ const renderTable = (config, baseAPIUrl) => {
                 if (tableType === 'scoreCard') {
                   const rows = parseScoreCardTableData(config, filteredData, selectedSubCounty);
                   root.render(<ScoreCardTable rows={rows} thresholds={thresholds} />);
+                } else if (tableType === 'dumbTable') {
+                  const rows = parseDumbTableData(config, filteredData, selectedSubCounty);
+                  root.render(<DistrictTable rows={rows} />);
                 } else {
                   const rows = parseTableData(config, filteredData, selectedSubCounty);
                   root.render(<DistrictTable rows={rows} />);

--- a/src/core/utils/tables.js
+++ b/src/core/utils/tables.js
@@ -68,20 +68,26 @@ export const validConfigs = (config, baseAPIUrl) => {
     return false;
   }
 
-  if (!config.mapping.rows) {
-    window.console.error('Invalid table config: mapping.series is required!');
+  if (!config.mapping.rows && !config.mapping.columns) {
+    window.console.error('Invalid table config: mapping.series or mapping.columns is required!');
 
     return false;
   }
 
-  if (!config.mapping.year) {
-    window.console.error('Invalid table config: mapping.year is required!');
+  if (!config.mapping.year && !config.mapping.columns) {
+    window.console.error('Invalid table config: mapping.year or mapping.columns is required!');
 
     return false;
   }
 
-  if (!config.mapping.value) {
-    window.console.error('Invalid table config: mapping.value is required!');
+  if (!config.mapping.value && !config.mapping.columns) {
+    window.console.error('Invalid table config: mapping.value or mapping.columns is required!');
+
+    return false;
+  }
+
+  if (config.tableType && (config.tableType === 'dumbTable' && !config.mapping.columns)) {
+    window.console.error('Invalid table config: mapping.columns is required when tableType === dumbTable!');
 
     return false;
   }
@@ -170,3 +176,16 @@ export const getTableCellColor = (() => {
     return '';
   };
 })();
+
+
+export const parseDumbTableData = (config, data, subCounty) => {
+  const { mapping } = config;
+
+  const tableColumns = mapping.columns.map((column) => Object.keys(column)[0]);
+  const headerRow = mapping.columns.map((column, index) => column[tableColumns[index]]);
+  const dataRows = data.filter((row) =>
+      subCounty !== defaultSelectValue ? row[mapping.subCounty].toLowerCase() === subCounty.toLowerCase() : true
+    ).map((item) => tableColumns.map((column) => item[column]));
+
+  return [headerRow].concat(dataRows);
+};

--- a/src/index.html
+++ b/src/index.html
@@ -326,6 +326,28 @@
           </div>
         </div>
       </section>
+
+      <section class="section">
+        <div class="row row--narrow">
+          <h3 class="type-l type-l--trailer">Dumb Table</h3>
+          <div class="chart-container chart-container--full">
+            <div class="charts__chart">
+              <!-- CODE TO COPY STARTS HERE {% endcomment %} -->
+              <div class="dumb-table-container"></div>
+              <!-- CODE TO COPY ENDS HERE {% endcomment %} -->
+
+              <div class="chart-loading">
+                <div class="chart-loading__block">
+                  <div></div>
+                  <div></div>
+                  <div></div>
+                  <div></div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
     </main>
   </div>
 
@@ -1807,6 +1829,7 @@
             ],
             // Use the below for both regular tables (i.e tables only without charts) and Score card
             tables: [{
+              // scoreCard
               target: 'education',
               className: 'score-card-container',
               dataID: 14482,
@@ -1819,12 +1842,13 @@
                   year: 'year',
                   value: 'value',
               },
-              // tableType and thresholds are needed only for scorecard tables
+              // tableType is needed only for scorecard tables and dumbTables
               /**
-              Endeavour to add <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devinit/ug-district-dashboard-viz@0.8.7-beta.2/assets/styles.css" />
+              Endeavour to add <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devinit/ug-district-dashboard-viz@0.8.8/assets/styles.css" />
               in the header section for the corresponding dashboard to pick correct styles for scorecard
               **/
               tableType: 'scoreCard',
+              // thresholds are needed only for scorecard tables
               thresholds: {
                   'Pupil to latrine stance ratio': 40,
                   'Pupil to desk ratio': 3,
@@ -1833,6 +1857,27 @@
                   'Primary school availability per parish': 71,
                   'Secondary school availability per subcounty': 13,
               },
+            },
+            {
+              // dumbTable - Used to display data as seen in an excel sheet without any modifications to it
+              target: 'education',
+              className: 'dumb-table-container',
+              dataID: 26883,
+              mapping: {
+                  //subCounty: 'Column for Sub-County',
+                  // columns is compulsory for dumbTables and ignored for rest
+                  columns: [
+                    { 'Name of the health facility/Clinic': 'Name of the Health Facility/Clinic'},
+                    { 'Healthy center level': 'Healthy Center Level'},
+                    { ' Immunization Services': ' Immunization Services'},
+                  ],
+              },
+              // tableType is needed only for scorecard tables and dumbTables. Can be scoreCard or dumbTable
+              /**
+              Endeavour to add <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/devinit/ug-district-dashboard-viz@0.8.8/assets/styles.css" />
+              in the header section for the corresponding dashboard to pick correct styles for scorecard
+              **/
+              tableType: 'dumbTable',
             },
             ],
             map: {


### PR DESCRIPTION
Adds functionality to display tables in a `dumb` way. No aggregation or any calculations is run on the table, simply think of it as a copy-paste from Excel to a webpage. You can only map column headings to new ones.